### PR TITLE
Making record parser public and addtional testing

### DIFF
--- a/dkim.go
+++ b/dkim.go
@@ -211,7 +211,7 @@ func Verify(email *[]byte) (verifyOutput, error) {
 	}
 
 	// we do not set query method because if it's others, validation failed earlier
-	pubKey, verifyOutputOnError, err := newPubKeyFromDnsTxt(dkimHeader.Selector, dkimHeader.Domain)
+	pubKey, verifyOutputOnError, err := NewPubKeyRespFromDNS(dkimHeader.Selector, dkimHeader.Domain)
 	if err != nil {
 		// fix https://github.com/toorop/go-dkim/issues/1
 		//return getVerifyOutput(verifyOutputOnError, err, pubKey.FlagTesting)

--- a/dkim.go
+++ b/dkim.go
@@ -200,7 +200,7 @@ func Sign(email *[]byte, options SigOptions) error {
 // state: SUCCESS or PERMFAIL or TEMPFAIL, TESTINGSUCCESS, TESTINGPERMFAIL
 // TESTINGTEMPFAIL or NOTSIGNED
 // error: if an error occurs during verification
-func Verify(email *[]byte) (verifyOutput, error) {
+func Verify(email *[]byte, opts ...DNSOpt) (verifyOutput, error) {
 	// parse email
 	dkimHeader, err := newDkimHeaderFromEmail(email)
 	if err != nil {
@@ -211,7 +211,7 @@ func Verify(email *[]byte) (verifyOutput, error) {
 	}
 
 	// we do not set query method because if it's others, validation failed earlier
-	pubKey, verifyOutputOnError, err := NewPubKeyRespFromDNS(dkimHeader.Selector, dkimHeader.Domain)
+	pubKey, verifyOutputOnError, err := NewPubKeyRespFromDNS(dkimHeader.Selector, dkimHeader.Domain, opts...)
 	if err != nil {
 		// fix https://github.com/toorop/go-dkim/issues/1
 		//return getVerifyOutput(verifyOutputOnError, err, pubKey.FlagTesting)

--- a/dkim_test.go
+++ b/dkim_test.go
@@ -2,9 +2,13 @@ package dkim
 
 import (
 	//"fmt"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -33,6 +37,17 @@ kS5vLkzRI84eiJrm3+IieUqIIicsO+WYxQs+JgVx5XhpPjX4SQjHtwEC2xKkWnEv
 
 	selector = "test"
 )
+
+func privKeyRSA(tb testing.TB) *rsa.PrivateKey {
+	block, rest := pem.Decode([]byte(privKey))
+	require.NotNil(tb, block)
+	require.Empty(tb, rest)
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	require.NoError(tb, err)
+
+	return key
+}
 
 var emailBase = "Received: (qmail 28277 invoked from network); 1 May 2015 09:43:37 -0000" + CRLF +
 	"Received: (qmail 21323 invoked from network); 1 May 2015 09:48:39 -0000" + CRLF +

--- a/pubKeyRep.go
+++ b/pubKeyRep.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"io/ioutil"
+	"mime/quotedprintable"
 	"net"
 	"strings"
 )
@@ -88,6 +90,10 @@ func NewPubKeyResp(dkimRecord string) (*PubKeyRep, verifyOutput, error) {
 				return nil, PERMFAIL, ErrVerifyBadKeyType
 			}
 		case "n":
+			qp, err := ioutil.ReadAll(quotedprintable.NewReader(strings.NewReader(val)))
+			if err == nil {
+				val = string(qp)
+			}
 			pkr.Note = val
 		case "p":
 			rawkey := val

--- a/pubKeyRep.go
+++ b/pubKeyRep.go
@@ -51,7 +51,6 @@ func NewPubKeyResp(dkimRecord string) (*PubKeyRep, verifyOutput, error) {
 	pkr.Version = "DKIM1"
 	pkr.HashAlgo = []string{"sha1", "sha256"}
 	pkr.KeyType = "rsa"
-	pkr.ServiceType = []string{"all"}
 	pkr.FlagTesting = false
 	pkr.FlagIMustBeD = false
 
@@ -111,12 +110,12 @@ func NewPubKeyResp(dkimRecord string) (*PubKeyRep, verifyOutput, error) {
 		case "s":
 			t := strings.Split(strings.ToLower(val), ":")
 			for _, tt := range t {
-				if tt == "*" {
-					pkr.ServiceType = []string{"all"}
-					break
-				}
-				if tt == "email" {
-					pkr.ServiceType = []string{"email"}
+				tt = strings.TrimSpace(tt)
+				switch tt {
+				case "*":
+					pkr.ServiceType = append(pkr.ServiceType, "all")
+				case "email":
+					pkr.ServiceType = append(pkr.ServiceType, tt)
 				}
 			}
 		case "t":
@@ -136,6 +135,11 @@ func NewPubKeyResp(dkimRecord string) (*PubKeyRep, verifyOutput, error) {
 	// if no pubkey
 	if pkr.PubKey == (rsa.PublicKey{}) {
 		return nil, PERMFAIL, ErrVerifyNoKey
+	}
+
+	// No service type
+	if len(pkr.ServiceType) == 0 {
+		pkr.ServiceType = []string{"all"}
 	}
 
 	return pkr, SUCCESS, nil

--- a/pubKeyRep.go
+++ b/pubKeyRep.go
@@ -121,11 +121,11 @@ func NewPubKeyResp(dkimRecord string) (*PubKeyRep, verifyOutput, error) {
 		case "t":
 			flags := strings.Split(strings.ToLower(val), ":")
 			for _, flag := range flags {
-				if flag == "y" {
+				flag = strings.TrimSpace(flag)
+				switch flag {
+				case "y":
 					pkr.FlagTesting = true
-					continue
-				}
-				if flag == "s" {
+				case "s":
 					pkr.FlagIMustBeD = true
 				}
 			}

--- a/pubKeyRep_test.go
+++ b/pubKeyRep_test.go
@@ -1,0 +1,397 @@
+package dkim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPubKeyRep(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		Name         string
+		Txt          string
+		Expect       *PubKeyRep
+		VerifyOutput verifyOutput
+		Err          error
+	}
+
+	testCases := []testCase{
+		{
+			Name: "only required",
+			Txt:  "p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name:         "empty record",
+			Txt:          "",
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyNoKey,
+		},
+
+		// v=
+		{
+			Name:         "version not first",
+			Txt:          "p=" + pubKey + "; v=DKIM1",
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyTagVMustBeTheFirst,
+		},
+		{
+			Name:         "wrong version",
+			Txt:          "v=DKIM2; p=" + pubKey,
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyVersionMusBeDkim1,
+		},
+
+		// p=
+		{
+			Name:         "no key",
+			Txt:          "v=DKIM1",
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyNoKey,
+		},
+		{
+			Name:         "key revoked",
+			Txt:          "v=DKIM1; p=",
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyRevokedKey,
+		},
+		{
+			Name:         "key invalid",
+			Txt:          "v=DKIM1; p=badBase64",
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyBadKey,
+		},
+
+		// h=
+		{
+			Name: "all supported hashes",
+			Txt:  "v=DKIM1; h=sha1:sha256; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "sha256 only",
+			Txt:  "v=DKIM1; h=sha256; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "sha1 only",
+			Txt:  "v=DKIM1; h=sha1; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "unsupported hash",
+			Txt:  "v=DKIM1; h=sha512; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "unsupported hash with supported hash",
+			Txt:  "v=DKIM1; h=sha256:sha512; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "empty hash list",
+			Txt:  "v=DKIM1; h=; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+
+		// k=
+		{
+			Name: "key type rsa",
+			Txt:  "v=DKIM1; k=rsa; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name:         "unsupported key type",
+			Txt:          "v=DKIM1; k=dsa; p=" + pubKey,
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyBadKeyType,
+		},
+		{
+			Name:         "empty key type",
+			Txt:          "v=DKIM1; k=; p=" + pubKey,
+			VerifyOutput: PERMFAIL,
+			Err:          ErrVerifyBadKeyType,
+		},
+
+		// n=
+		{
+			Name: "with note",
+			Txt:  "v=DKIM1; n=a note; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				Note:        "a note",
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "with note (qp)",
+			Txt:  "v=DKIM1; n=a note=3B encoded as quoted printable; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				Note:        "a note; encoded as quoted printable",
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "with note (bad qp)",
+			Txt:  "v=DKIM1; n=a note =! with invalid quoted printable; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				Note:        "a note =! with invalid quoted printable",
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "empty note",
+			Txt:  "v=DKIM1; n=; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+
+		// s=
+		{
+			Name: "any service",
+			Txt:  "v=DKIM1; s=*; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "email service",
+			Txt:  "v=DKIM1; s=email; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"email"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "all services",
+			Txt:  "v=DKIM1; s=* : email; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all", "email"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "unsupported service",
+			Txt:  "v=DKIM1; s=unknown; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "unsupported service with supported service",
+			Txt:  "v=DKIM1; s=unknown:email; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"email"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "empty services",
+			Txt:  "v=DKIM1; s=; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+
+		// t=
+		{
+			Name: "testing mode",
+			Txt:  "v=DKIM1; t=y; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+				FlagTesting: true,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "strict mode",
+			Txt:  "v=DKIM1; t=s; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:      "DKIM1",
+				HashAlgo:     []string{"sha1", "sha256"},
+				KeyType:      "rsa",
+				ServiceType:  []string{"all"},
+				PubKey:       privKeyRSA(t).PublicKey,
+				FlagIMustBeD: true,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "both test flags",
+			Txt:  "v=DKIM1; t=y : s; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:      "DKIM1",
+				HashAlgo:     []string{"sha1", "sha256"},
+				KeyType:      "rsa",
+				ServiceType:  []string{"all"},
+				PubKey:       privKeyRSA(t).PublicKey,
+				FlagTesting:  true,
+				FlagIMustBeD: true,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "include invalid test flag",
+			Txt:  "v=DKIM1; t=y:s:?; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:      "DKIM1",
+				HashAlgo:     []string{"sha1", "sha256"},
+				KeyType:      "rsa",
+				ServiceType:  []string{"all"},
+				PubKey:       privKeyRSA(t).PublicKey,
+				FlagTesting:  true,
+				FlagIMustBeD: true,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "invalid test flag",
+			Txt:  "v=DKIM1; t=?; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+		{
+			Name: "empty test flags",
+			Txt:  "v=DKIM1; t=; p=" + pubKey,
+			Expect: &PubKeyRep{
+				Version:     "DKIM1",
+				HashAlgo:    []string{"sha1", "sha256"},
+				KeyType:     "rsa",
+				ServiceType: []string{"all"},
+				PubKey:      privKeyRSA(t).PublicKey,
+			},
+			VerifyOutput: SUCCESS,
+		},
+	}
+
+	for _, tc := range testCases {
+		// Subtests are actually run in goroutines, so make sure to capture the loop var
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			pubKeyRep, vo, err := NewPubKeyResp(tc.Txt)
+			if tc.Err != nil {
+				assert.EqualError(t, err, tc.Err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.VerifyOutput, vo)
+			assert.EqualValues(t, tc.Expect, pubKeyRep)
+		})
+	}
+}


### PR DESCRIPTION
These changes exist in dc/tests and dc/parse with PRs open to the original fork.